### PR TITLE
Fixes the bad json escaping from previously escaped to string to EOF.

### DIFF
--- a/zoidberg/nix-channel-monitor/changes.sh
+++ b/zoidberg/nix-channel-monitor/changes.sh
@@ -18,7 +18,7 @@ publish() {
     "properties": {},
     "routing_key": "queue-publish",
     "payload_encoding": "string",
-    "payload": "{\"target\": \"#nixos\", \"body\": \"'"$msg"'\", \"message_type\": \"notice\"}"
+    "payload": "{\"target\": \"#nixos\", \"body\": \"$msg\", \"message_type\": \"notice\"}"
 }
 EOF
 


### PR DESCRIPTION
Previously:

    \"'"$msg"'\" → \"'"hi"'\"

Now:

    \"$msg\" → \"hi\"

* * * 

Sorry!