### PR TITLE
Point nix-channel-monitor to nixpkgs instead of nixpkgs-channels

### DIFF
--- a/flexo/nix-channel-monitor/changes.sh
+++ b/flexo/nix-channel-monitor/changes.sh
@@ -110,7 +110,7 @@ readonly dest="$2"
     cd "$gitrepo" >&2
     git fetch "$remote"  >&2
     git for-each-ref --format '%(refname:strip=3)' \
-        "refs/remotes/$remote"
+        "refs/remotes/$remote/nixos-*" "refs/remotes/$remote/nixpkgs-*"
 ) | grep -v HEAD |
     (
         cd "$dest"

--- a/flexo/nix-channel-monitor/default.nix
+++ b/flexo/nix-channel-monitor/default.nix
@@ -43,9 +43,11 @@
 
       preStart = ''
         set -eux
+        remote=https://github.com/nixos/nixpkgs.git
         if [ ! -d /var/lib/nix-channel-monitor/git ]; then
-          git clone https://github.com/nixos/nixpkgs-channels.git git
+          git clone "$remote" git
         fi
+        git -C /var/lib/nix-channel-monitor/git remote set-url origin "$remote"
       '';
 
       script = let


### PR DESCRIPTION
nixpkgs-channels has been deprecated and won't be updated anymore

Tested this with a different domain and no amqp